### PR TITLE
Add #id to EncryptedData

### DIFF
--- a/lib/xml/kit/encrypted_data.rb
+++ b/lib/xml/kit/encrypted_data.rb
@@ -7,16 +7,19 @@ module Xml
     #
     # @since 0.3.0
     class EncryptedData
+      attr_reader :id
       attr_reader :key_info
       attr_reader :symmetric_cipher
       attr_reader :symmetric_cipher_value
 
       def initialize(
         raw_xml,
+        id: Id.generate,
         symmetric_cipher:,
         asymmetric_cipher:,
         key_info: nil
       )
+        @id = id
         @symmetric_cipher = symmetric_cipher
         @symmetric_cipher_value = Base64.strict_encode64(
           symmetric_cipher.encrypt(raw_xml)

--- a/spec/xml/kit/encrypted_data_spec.rb
+++ b/spec/xml/kit/encrypted_data_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe Xml::Kit::EncryptedData do
       ].each do |symmetric_algorithm|
         describe symmetric_algorithm do
           subject do
-            described_class.new(xml, symmetric_cipher: symmetric_cipher, asymmetric_cipher: asymmetric_cipher)
+            described_class.new(xml, id: id, symmetric_cipher: symmetric_cipher, asymmetric_cipher: asymmetric_cipher)
           end
 
+          let(:id) { ::Xml::Kit::Id.generate }
           let(:symmetric_cipher) { ::Xml::Kit::Crypto::SymmetricCipher.new(symmetric_algorithm) }
           let(:asymmetric_cipher) { ::Xml::Kit::Crypto.cipher_for(asymmetric_algorithm, key_pair.public_key) }
           let(:key_pair) { Xml::Kit::KeyPair.generate(use: :encryption, algorithm: symmetric_algorithm) }


### PR DESCRIPTION
As proposed in #6:

Align `EncryptedData` to EncryptedKey` by adding an `Id` either auto-generated or
explicit passed via constructor.

@mokhan should I add it to template as well? wyt?